### PR TITLE
ci: Add basic workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,16 @@
+on:
+  workflow_dispatch:
+  push:
+    branches: [ "main" ]
+    tags: [ "*" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest-16-cores
+
+    steps:
+      - name: Install dependencies
+        run: apt-get install maven
+


### PR DESCRIPTION
Without this, it's not possible to test any CI workflows on a branch.